### PR TITLE
fix Earthdata example (almost?)

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,23 +60,33 @@ Retrieve a list of OPeNDAP URLs from the NASA [Common Metadata Repository (CMR)]
 
 
 ```julia
-using STAC, URIs, Dates
+using STAC, Dates, Downloads
 
 token = "put_your_user_token_here"
-timerange = (DateTime(2019,1,1),DateTime(2019,12,31))
+timerange = (DateTime(2005,1,1),DateTime(2005,1,31))
 collection_concept_id = "C1996881146-POCLOUD"
 baseurl = "https://cmr.earthdata.nasa.gov/search/granules.stac"
 
-url = string(URI(URI(baseurl), query = Dict(
-    "collection_concept_id" => collection_concept_id,
+query = Dict(
     "temporal" => join(string.(timerange),','),
     "pageSize" => 1000, # default is 100
-    "token" => token)))
+    )
 
-collection = STAC.FeatureCollection(url)
-opendap_url = [href(item.assets["opendap"]) for item in collection]
+url=baseurl*"?collection_concept_id=$(collection_concept_id)&temporal="*query["temporal"]
 
-@show length(opendap_url)
+collection = STAC.FeatureCollection(url,Dict())
+
+#the following commands may require authentification
+
+item=take!(collection)
+Downloads.download(href(item.assets["data"]))
+
+#the following commands need more fixing it seems
+
+#collection = STAC.FeatureCollection(url,query)
+#opendap_url = [href(item.assets["opendap"]) for item in collection]
+
+#@show length(opendap_url)
 # output 365, one URL per day
 ```
 

--- a/src/search.jl
+++ b/src/search.jl
@@ -4,7 +4,12 @@ function FeatureCollection(url,query)
     ch = Channel{STAC.Item}() do c
         while true
             @debug "post $url" query
-            r = HTTP.post(url,[],JSON3.write(query))
+            if !isempty(query)
+                r = HTTP.post(url,[],JSON3.write(query))
+            else
+                r = HTTP.post(url)
+                #r=HTTP.get(url)
+        end
             data = JSON3.read(String(r.body))
             for d in data[:features]
                 put!(c,STAC.Item("",d,STAC._assets(d)))
@@ -16,7 +21,9 @@ function FeatureCollection(url,query)
             if length(next) == 0
                 break
             else
-                url = next[1][:href]
+				a=next[1][:body][:collection_concept_id]
+				b=next[1][:body][:page_num]
+				url = next[1][:href]*"?collection_concept_id=$(a)&page_num=$(b)"
             end
         end
     end


### PR DESCRIPTION
It seems that requests to https://cmr.earthdata.nasa.gov/search/granules.stac now require that the url includes a `collection_concept_id`. The modification to `src/search.jl` does this and allows for an empty `query` specification. 

In the example, the handling of url, query v FeatureCollection also needed an update after https://github.com/JuliaClimate/STAC.jl/commit/918a1a95649769b01da5c26c8f1cd6d8761bdbbc I believe.

Some problems that may remain : 

- `[href(item.assets["opendap"]) for item in collection]` fails cause `collection` does not end properly?
- `collection = STAC.FeatureCollection(url,query)` fails, not sure why



