### PR TITLE
Add pretty printing for OrderedDictWrapper and check for Catalog type in construction

### DIFF
--- a/src/STAC.jl
+++ b/src/STAC.jl
@@ -1,6 +1,6 @@
 module STAC
 
-import Base: keys, values, getindex, show, length, iterate
+import Base: keys, values, getindex, show, length, iterate, ==
 import CFTime
 import Dates: DateTime
 import Dates

--- a/src/asset.jl
+++ b/src/asset.jl
@@ -17,6 +17,8 @@ Get the $($name) of a STAC `asset` (or `default` if it is not specified).
     end
 end
 
+(==)(a1::Asset, a2::Asset) = a1.data == a2.data
+
 function Base.show(io::IO,asset::Asset)
     _printstyled(io, "title: ",title(asset), "\n", bold=true, color=title_color[])
     _printstyled(io, description(asset), "\n")

--- a/src/catalog.jl
+++ b/src/catalog.jl
@@ -207,9 +207,12 @@ end
 
 children_ids(catalog::Catalog) = _rel_ids(Catalog,catalog,:child)
 child(catalog::Catalog,id::AbstractString) = _rel(Catalog,catalog,:child,id)
+odwtype(::typeof(STAC.child)) = "Children of "
 
 items_ids(catalog::Catalog) = _rel_ids(Item,catalog,:item)
 item(catalog::Catalog,id::AbstractString) = _rel(Item,catalog,:item,id)
+odwtype(::typeof(STAC.item)) = "Items of "
+
 
 @inline function Base.getproperty(catalog::Catalog,name::Symbol)
     if (name == :children)

--- a/src/catalog.jl
+++ b/src/catalog.jl
@@ -118,6 +118,11 @@ function Catalog(url::String; parent = nothing, limit = 200)
     if !haskey(data,:id)
         throw(ArgumentError("The mandatory STAC id element is missing in $url"))
     end
+    if haskey(data, :type)
+        if data[:type] !== "Catalog"
+            throw(ArgumentError("The provided STAC url is of type $(data[:type]). Expected a STAC url of type Catalog."))
+        end
+    end
 
     assets = _assets(data)
 

--- a/src/item.jl
+++ b/src/item.jl
@@ -7,6 +7,10 @@ struct Item
     parent
 end
 
+function (==)(item1::Item, item2::Item)
+    comps = [getproperty(item1,k)==getproperty(item2,k) for k in fieldnames(Item)]
+    all(comps) 
+end
 # https://github.com/radiantearth/stac-spec/blob/master/item-spec/item-spec.md
 
 for (prop,name) in ((:id, "identifier"),

--- a/src/search.jl
+++ b/src/search.jl
@@ -31,9 +31,7 @@ function FeatureCollection(url,query; method=:get, _enctype = :form_urlencoded)
                 @debug "get $url"
                 r = HTTP.get(url)
             end
-            @show r
             data = JSON3.read(String(r.body))
-            @show keys(data)
             for d in data[:features]
                 geojson = GeoJSON.read(JSON3.write(d))
                 put!(c,STAC.Item("",d,geojson,STAC._assets(d),nothing))

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -59,7 +59,20 @@ end
 
 Base.keys(odw::OrderedDictWrapper) = odw.keys(odw.data)
 Base.getindex(odw::OrderedDictWrapper,key) = odw.getindex(odw.data,key)
-Base.getindex(odw::OrderedDictWrapper, key::Integer) = odw.getindex(odw.data, keys(odw)[key])
+function Base.getindex(odw::OrderedDictWrapper, intkey::Integer)
+    odwkeys = keys(odw)
+    outkey = eltype(odwkeys)[]
+    for (i, key) in enumerate(odwkeys)
+        if i == intkey
+            push!(outkey, key)
+            break
+        end
+    end
+    if isempty(outkey)
+        throw(BoundsError(odw, intkey))
+    end
+    odw.getindex(odw.data, outkey[1])
+end
 
 function Base.show(io::IO, m::MIME"text/plain", odw::OrderedDictWrapper)
     _printstyled(io, typeof(odw),"\n")

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -22,9 +22,9 @@ function Base.keys(ld::LazyOrderedDict)
 end
 
 function Base.getindex(ld::LazyOrderedDict{K,V},id::K) where {K,V}
-    if ld.getindex_guess != nothing
+    if ld.getindex_guess !== nothing
         guess = ld.getindex_guess(ld.list,ld.fun,id)
-        if guess != nothing
+        if guess !== nothing
             return guess
         end
     end
@@ -59,8 +59,15 @@ end
 
 Base.keys(odw::OrderedDictWrapper) = odw.keys(odw.data)
 Base.getindex(odw::OrderedDictWrapper,key) = odw.getindex(odw.data,key)
+Base.getindex(odw::OrderedDictWrapper, key::Integer) = odw.getindex(odw.data, keys(odw)[key])
 
+function Base.show(io::IO, m::MIME"text/plain", odw::OrderedDictWrapper)
+    _printstyled(io, typeof(odw),"\n")
+    _printstyled(io, odwtype(odw.getindex))
+    _printstyled(io, "Parent Catalog: ", title(odw.data))
+end
 
+odwtype(x) = string(x) * " of "
 Base.length(odw::OrderedDictWrapper) = length(collect(keys(odw)))
 
 # https://github.com/JuliaLang/julia/blob/95c643a689293eb91a47cc83c41533a94c3677cc/base/channels.jl

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -80,6 +80,7 @@ function Base.show(io::IO, m::MIME"text/plain", odw::OrderedDictWrapper)
     _printstyled(io, "Parent Catalog: ", title(odw.data))
 end
 
+Base.show(io::IO, odw::OrderedDictWrapper) = show(io, MIME("text/plain"), odw) 
 odwtype(x) = string(x) * " of "
 Base.length(odw::OrderedDictWrapper) = length(collect(keys(odw)))
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -44,6 +44,7 @@ end
     item = subcat1.items["LC08_L1TP_152038_20200611_20200611_01_RT"]
     itemint = subcat1.items[1]
     @test item == itemint
+    @test_throws BoundsError subcat1.items[2]
     testshow(item,"box")
     testshow(item, "LC08_L1TP_152038_20200611_20200611_01_RT")
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -38,9 +38,14 @@ end
 
     @test subcat1 isa STAC.Catalog
     testshow(subcat1,"Items")
+    subitems = subcat1.items
+    testshow(subitems, "Parent Catalog")
 
     item = subcat1.items["LC08_L1TP_152038_20200611_20200611_01_RT"]
+    itemint = subcat1.items[1]
+    @test item == itemint
     testshow(item,"box")
+    testshow(item, "LC08_L1TP_152038_20200611_20200611_01_RT")
 
     @test geometry(item) isa STAC.GeoJSON.Polygon
     @test bbox(item) isa AbstractVector

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -84,6 +84,10 @@ end
     @test length(STAC.CACHE) == 0
 end
 
+@testset "Malformed URL" begin
+    @test_throws ArgumentError STAC.Catalog("https://geoservice.dlr.de/eoc/ogc/stac/v1/collections/TDM_FNF_50")
+    @test_throws ArgumentError STAC.Catalog("https://stac.core.eopf.eodc.eu/collections")
+end
 
 
 @testset "search" begin


### PR DESCRIPTION
This adds a check for the type key in the Catalog construction if it is available. 
This also adds a pretty printing for OrderedDictWrapper to make it lazy. 

I also added a function to get the search url because this should be provided as an entry in the JSON file with some metadata. 

For the Catalog check we test whether the type key is available because according to https://github.com/JuliaClimate/STAC.jl/issues/22#issuecomment-3075521866 this is not always provided. 

