### PR TITLE
Fix datetime assume UTC allow ranges

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,10 +1,9 @@
 name = "STAC"
 uuid = "08e62803-e111-4f53-be9b-274ff296e9da"
-authors = ["Alexander Barth <barth.alexander@gmail.com> and contributors"]
 version = "0.1.6"
+authors = ["Alexander Barth <barth.alexander@gmail.com> and contributors"]
 
 [deps]
-CFTime = "179af706-886a-5703-950a-314cd64e0468"
 DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 GeoJSON = "61d90e0f-e114-555e-ac52-39dfb47a3ef9"
@@ -16,7 +15,6 @@ Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 URIs = "5c2747f8-b7ea-4ff2-ba2e-563bfd36b1d4"
 
 [compat]
-CFTime = "0.1, 0.2"
 DataStructures = "0.18, 0.19"
 GeoJSON = "0.8"
 HTTP = "0.9, 1"

--- a/examples/Install-Julia-on-pangeo.ipynb
+++ b/examples/Install-Julia-on-pangeo.ipynb
@@ -34,7 +34,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%env JULIA_PACKAGES=IJulia PyPlot HTTP JSON3 Zarr CFTime PyCall URIs Images"
+    "%env JULIA_PACKAGES=IJulia PyPlot HTTP JSON3 Zarr PyCall URIs Images"
    ]
   },
   {

--- a/examples/Julia-pangeo-STAC-Zarr.ipynb
+++ b/examples/Julia-pangeo-STAC-Zarr.ipynb
@@ -16,13 +16,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": null,
    "id": "worse-graphics",
    "metadata": {},
    "outputs": [],
    "source": [
     "using Pkg\n",
-    "#Pkg.add([\"CFTime\",\"HTTP\",\"JSON3\",\"PyPlot\",URIs\"])\n",
+    "Pkg.add([\"CFTime\",\"HTTP\",\"JSON3\",\"PyPlot\",\"URIs\"])\n",
     "#Pkg.add(url=\"https://github.com/JuliaClimate/STAC.jl\")"
    ]
   },
@@ -46,12 +46,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "id": "likely-devon",
    "metadata": {},
    "outputs": [],
    "source": [
-    "using CFTime, HTTP, JSON3, PyPlot, Zarr, URIs\n",
+    "using HTTP, JSON3, PyPlot, Zarr, URIs\n",
     "using STAC"
    ]
   },

--- a/src/STAC.jl
+++ b/src/STAC.jl
@@ -1,7 +1,6 @@
 module STAC
 
 import Base: keys, values, getindex, show, length, iterate, ==
-import CFTime
 import Dates: DateTime
 import Dates
 import GeoJSON: geometry

--- a/src/item.jl
+++ b/src/item.jl
@@ -28,6 +28,18 @@ Get the $($name) of STAC `item`.
     end
 end
 
+"""
+Get the date time of a STAC item field, defaults to UTC.
+Returns `nothing` if the field is not present
+"""
+function get_datetime(item::Item, field::Symbol;
+    date_format::Dates.DateFormat=Dates.dateformat"yyyy-mm-ddTHH:MM:SS.sZ")
+    dt = get(item.data.properties, field, nothing)
+    isnothing(dt) && return nothing
+    dt_utc = DateTime(dt, date_format)
+    return dt_utc
+end
+
 
 """
     dt = DateTime(item)
@@ -37,20 +49,13 @@ if this properties is not specified).
 Get the start date time if the item has a timespan instead.
 """
 function DateTime(item::Item)
-    # should be UTC
     # mainly in field datetime
-    try
-        dt = get(item.data.properties, :datetime, nothing)
-        return DateTime(dt, Dates.dateformat"yyyy-mm-ddTHH:MM:SS.sZ")
-    catch
-    end
+    dt = get_datetime(item, :datetime)
+    !isnothing(dt) && return dt
 
     # may be a range, take the start
-    try
-        dt = get(item.data.properties, :start_datetime, nothing)
-        return DateTime(dt, Dates.dateformat"yyyy-mm-ddTHH:MM:SS.sZ")
-    catch
-    end
+    dt = get_datetime(item, :start_datetime)
+    !isnothing(dt) && return dt
 
     # found nothing
     return nothing

--- a/src/item.jl
+++ b/src/item.jl
@@ -45,7 +45,7 @@ function parse_datetime(s::AbstractString;
     end
 end
 
-function get_datetime(item::Item, prop::Symbol)
+function datetime(item::Item, prop::Symbol)
     s = get(item.data.properties, prop, nothing)
     isnothing(s) && return nothing
     return parse_datetime(s)
@@ -61,11 +61,11 @@ Get the start date time if the item has a timespan instead.
 """
 function DateTime(item::Item)
     # mainly in field datetime
-    dt = get_datetime(item, :datetime)
+    dt = datetime(item, :datetime)
     !isnothing(dt) && return dt
 
     # may be a range, take the start
-    dt = get_datetime(item, :start_datetime)
+    dt = datetime(item, :start_datetime)
     !isnothing(dt) && return dt
 
     # found nothing
@@ -112,10 +112,10 @@ $(west)              $(east)
 """)
 
     if :start_datetime in keys(item.data.properties) && :end_datetime in keys(item.data.properties)
-        printstyled(io, "start date time: ",get_datetime(item,:start_datetime),"\n")
-        printstyled(io, "  end date time: ",get_datetime(item,:end_datetime),"\n")
+        printstyled(io, "start date time: ",datetime(item,:start_datetime),"\n")
+        printstyled(io, "  end date time: ",datetime(item,:end_datetime),"\n")
     elseif :datetime in keys(item.data.properties)
-        printstyled(io, "date time: ",get_datetime(item,:datetime),"\n")
+        printstyled(io, "date time: ",datetime(item,:datetime),"\n")
     end
 
     _show_assets(io,item)

--- a/src/item.jl
+++ b/src/item.jl
@@ -28,16 +28,27 @@ Get the $($name) of STAC `item`.
     end
 end
 
-"""
-Get the date time of a STAC item field, defaults to UTC.
-Returns `nothing` if the field is not present
-"""
-function get_datetime(item::Item, field::Symbol;
+function parse_datetime(s::AbstractString;
     date_format::Dates.DateFormat=Dates.dateformat"yyyy-mm-ddTHH:MM:SS.sZ")
-    dt = get(item.data.properties, field, nothing)
-    isnothing(dt) && return nothing
-    dt_utc = DateTime(dt, date_format)
-    return dt_utc
+    
+    # remove default UTC zone
+    if endswith(s,"Z")
+        s = s[1:end-1]
+    end
+    
+    try
+        dt = DateTime(s, date_format)
+        return dt
+    catch e
+        e isa ArgumentError && return nothing
+        rethrow()
+    end
+end
+
+function get_datetime(item::Item, prop::Symbol)
+    s = get(item.data.properties, prop, nothing)
+    isnothing(s) && return nothing
+    return parse_datetime(s)
 end
 
 

--- a/src/item.jl
+++ b/src/item.jl
@@ -111,7 +111,13 @@ $(west)              $(east)
 
 """)
 
-    _printstyled(io, "date time: ",DateTime(item),"\n")
+    if :start_datetime in keys(item.data.properties) && :end_datetime in keys(item.data.properties)
+        printstyled(io, "start date time: ",get_datetime(item,:start_datetime),"\n")
+        printstyled(io, "  end date time: ",get_datetime(item,:end_datetime),"\n")
+    elseif :datetime in keys(item.data.properties)
+        printstyled(io, "date time: ",get_datetime(item,:datetime),"\n")
+    end
+
     _show_assets(io,item)
 end
 

--- a/src/item.jl
+++ b/src/item.jl
@@ -34,6 +34,7 @@ end
 
 Get the date time of STAC `item` as a `Dates.DateTime` (or `nothing`
 if this properties is not specified).
+Get the start date time if the item has a timespan instead.
 """
 function DateTime(item::Item)
     # should be UTC

--- a/src/item.jl
+++ b/src/item.jl
@@ -36,13 +36,23 @@ Get the date time of STAC `item` as a `Dates.DateTime` (or `nothing`
 if this properties is not specified).
 """
 function DateTime(item::Item)
-    dt = get(item.data.properties,:datetime,nothing)
-
-    if !isnothing(dt)
-        return CFTime.parseDT(Dates.DateTime,dt)
-    else
-        return nothing
+    # should be UTC
+    # mainly in field datetime
+    try
+        dt = get(item.data.properties, :datetime, nothing)
+        return DateTime(dt, Dates.dateformat"yyyy-mm-ddTHH:MM:SS.sZ")
+    catch
     end
+
+    # may be a range, take the start
+    try
+        dt = get(item.data.properties, :start_datetime, nothing)
+        return DateTime(dt, Dates.dateformat"yyyy-mm-ddTHH:MM:SS.sZ")
+    catch
+    end
+
+    # found nothing
+    return nothing
 end
 export DateTime
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -48,6 +48,10 @@ end
     testshow(item,"box")
     testshow(item, "LC08_L1TP_152038_20200611_20200611_01_RT")
 
+    @test DateTime(item) == DateTime("2020-06-11T05:54:44.650")
+    @test STAC.get_datetime(item, :datetime) == DateTime("2020-06-11T05:54:44.650") 
+    @test STAC.get_datetime(item, :start_datetime) === nothing
+
     @test geometry(item) isa STAC.GeoJSON.Polygon
     @test bbox(item) isa AbstractVector
     @test links(item) isa AbstractVector

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -50,8 +50,8 @@ end
     testshow(item, "date time:")
 
     @test DateTime(item) == DateTime("2020-06-11T05:54:44.65")
-    @test STAC.get_datetime(item, :datetime) == DateTime("2020-06-11T05:54:44.65")
-    @test STAC.get_datetime(item, :start_datetime) === nothing
+    @test STAC.datetime(item, :datetime) == DateTime("2020-06-11T05:54:44.65")
+    @test STAC.datetime(item, :start_datetime) === nothing
     
     @test STAC.parse_datetime("2026-07-31T11:50:12.123Z") == DateTime("2026-07-31T11:50:12.123")
     @test STAC.parse_datetime("2026-07-31T11:50:12.123") == DateTime("2026-07-31T11:50:12.123")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -48,9 +48,17 @@ end
     testshow(item,"box")
     testshow(item, "LC08_L1TP_152038_20200611_20200611_01_RT")
 
-    @test DateTime(item) == DateTime("2020-06-11T05:54:44.650")
-    @test STAC.get_datetime(item, :datetime) == DateTime("2020-06-11T05:54:44.650") 
+    @test DateTime(item) == DateTime("2020-06-11T05:54:44.65")
+    @test STAC.get_datetime(item, :datetime) == DateTime("2020-06-11T05:54:44.65")
     @test STAC.get_datetime(item, :start_datetime) === nothing
+    
+    @test STAC.parse_datetime("2026-07-31T11:50:12.123Z") == DateTime("2026-07-31T11:50:12.123")
+    @test STAC.parse_datetime("2026-07-31T11:50:12.123") == DateTime("2026-07-31T11:50:12.123")
+    @test STAC.parse_datetime("2026-07-31T11:50:12") == DateTime("2026-07-31T11:50:12")
+    @test STAC.parse_datetime("2026-07-31T11:50:12Z") == DateTime("2026-07-31T11:50:12")
+    @test STAC.parse_datetime("2026-07-31T11:50") == DateTime("2026-07-31T11:50")
+    @test STAC.parse_datetime("2026-07-31") == DateTime("2026-07-31")
+    @test STAC.parse_datetime("foo") === nothing
 
     @test geometry(item) isa STAC.GeoJSON.Polygon
     @test bbox(item) isa AbstractVector

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -47,6 +47,7 @@ end
     @test_throws BoundsError subcat1.items[2]
     testshow(item,"box")
     testshow(item, "LC08_L1TP_152038_20200611_20200611_01_RT")
+    testshow(item, "date time:")
 
     @test DateTime(item) == DateTime("2020-06-11T05:54:44.65")
     @test STAC.get_datetime(item, :datetime) == DateTime("2020-06-11T05:54:44.65")


### PR DESCRIPTION
This PR aims to fix the error of parsing datetime e.g. at CDSE. Consider the README example:

````julia
using STAC, Dates

collections = ["sentinel-2-l1c"]
time_range = (DateTime(2026,2,9,10,20), DateTime(2026,2,9,10,30))
lon_range = (0, 20)  # west, east
lat_range = (32, 45)  # south, north

catalog = STAC.Catalog("https://stac.dataspace.copernicus.eu/v1/")

search_results = collect(search(catalog, collections, lon_range, lat_range, time_range))
````

returns error 

```
search_results = collect(search(catalog, collections, lon_range, lat_range, time_range))
77-element Vector{STAC.Item}:
Error showing value of type Vector{STAC.Item}:

SYSTEM (REPL): showing an error caused an error
ERROR: 1-element ExceptionStack:
MethodError: no method matching parseDT(::Type{DateTime}, ::String)
The function `parseDT` exists, but no method is defined for this combination of argument types.

Closest candidates are:
  parseDT(::Type{Tuple}, ::Any)
   @ CFTime ~/.julia/packages/CFTime/5SQZS/src/conversions.jl:106

```

According to [STAC Spec 1.1](https://github.com/radiantearth/stac-spec/blob/v1.1.0/item-spec/item-spec.md#datetime), acquisition time of STAC items is mainly stored in filed `datetime`, SHOULD be in UTC, and may be an interval instead from `start_datetime` to `end_datetime`.

Therefore, I used `Dates.dateformat"yyyy-mm-ddTHH:MM:SS.sZ"`, also tried start of datetime range, and kept returning `nothing` otherwise.