### PR TITLE
Add compact show methods for asset catalog and item

### DIFF
--- a/src/asset.jl
+++ b/src/asset.jl
@@ -19,9 +19,13 @@ end
 
 (==)(a1::Asset, a2::Asset) = a1.data == a2.data
 
-function Base.show(io::IO,asset::Asset)
+function Base.show(io::IO, mime::MIME"text/plain", asset::Asset)
     _printstyled(io, "title: ",title(asset), "\n", bold=true, color=title_color[])
     _printstyled(io, description(asset), "\n")
     _printstyled(io, "type: ",type(asset), "\n")
     _printstyled(io, "href: ",href(asset), "\n")
+end
+
+function Base.show(io::IO, asset::Asset)
+    print(io, title(asset; default=href(asset)))
 end

--- a/src/catalog.jl
+++ b/src/catalog.jl
@@ -6,7 +6,7 @@ struct Catalog
     limit::Int
 end
 
-function Base.show(io::IO,cat::Catalog)
+function Base.show(io::IO, mime::MIME"text/plain", cat::Catalog)
     printstyled(io, id(cat), "\n", bold=true, color=title_color[])
     _printstyled(io, title(cat), "\n")
     _printstyled(io, description(cat), "\n")
@@ -39,6 +39,10 @@ function Base.show(io::IO,cat::Catalog)
     end
 
     _show_assets(io,cat)
+end
+
+function Base.show(io::IO, cat::Catalog)
+    print(io, id(cat))
 end
 
 

--- a/src/item.jl
+++ b/src/item.jl
@@ -64,7 +64,7 @@ function Item(url; parent = nothing)
 end
 
 
-function Base.show(io::IO,item::Item)
+function Base.show(io::IO, mime::MIME"text/plain", item::Item)
     fmt(x) = @sprintf("%9.5f",x)
 
     bb = bbox(item);
@@ -88,6 +88,9 @@ $(west)              $(east)
     _show_assets(io,item)
 end
 
+function Base.show(io::IO, item::Item)
+    print(io, id(item))
+end
 
 Base.keys(item::Item) = keys(item.assets)
 Base.values(item::Item) = values(item.assets)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -8,13 +8,19 @@ function testshow(s,substr)
     @test occursin(substr,String(take!(io)))
 end
 
+function testshow(mime::Type{<:MIME},s,substr)
+    io = IOBuffer()
+    show(io,mime(),s)
+    @test occursin(substr,String(take!(io)))
+end
+
 @testset "STAC.jl" begin
 
     url = "https://raw.githubusercontent.com/sat-utils/sat-stac/master/test/catalog/catalog.json"
 
     cat = STAC.Catalog(url)
 
-    testshow(cat,"STAC")
+    testshow(MIME"text/plain",cat,"STAC")
 
     @test id(cat) == "stac-catalog"
     @test occursin("1.",stac_version(cat))
@@ -37,7 +43,7 @@ end
     subcat1 = subcat["landsat-8-l1"]
 
     @test subcat1 isa STAC.Catalog
-    testshow(subcat1,"Items")
+    testshow(MIME"text/plain",subcat1,"Items")
     subitems = subcat1.items
     testshow(subitems, "Parent Catalog")
 
@@ -45,7 +51,7 @@ end
     itemint = subcat1.items[1]
     @test item == itemint
     @test_throws BoundsError subcat1.items[2]
-    testshow(item,"box")
+    testshow(MIME"text/plain",item,"box")
     testshow(item, "LC08_L1TP_152038_20200611_20200611_01_RT")
 
     @test geometry(item) isa STAC.GeoJSON.Polygon
@@ -62,7 +68,13 @@ end
     @test keys(item) == keys(item.assets)
     @test values(item) == values(item.assets)
 
-    testshow(assetB4,"type")
+    # plain text show methods
+    testshow(MIME"text/plain", assetB4, "type")
+    testshow(MIME"text/plain", cat, "STAC")
+
+    # compact show methods
+    testshow(assetB4, "Band 4")  # compact Asset show prints title
+    testshow(cat, "stac-catalog")  # compact Catalog show prints id
 
     STAC.set_cache_max_size(10000)
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -53,7 +53,7 @@ end
     @test_throws BoundsError subcat1.items[2]
     testshow(MIME"text/plain",item,"box")
     testshow(item, "LC08_L1TP_152038_20200611_20200611_01_RT")
-    testshow(item, "date time:")
+    testshow(MIME"text/plain",item, "date time:")
 
     @test DateTime(item) == DateTime("2020-06-11T05:54:44.65")
     @test STAC.datetime(item, :datetime) == DateTime("2020-06-11T05:54:44.65")


### PR DESCRIPTION
Show methods for structs in this package are comprehensive but overwhelming.
This PR aims to reduce the text output of showing dozens or even more search results by introducing a compact show method for catalog, item and asset:

```
julia> catalog
cdse-stac
Copernicus Data Space Ecosystem (CDSE) asset-level STAC catalogue
A comprehensive and searchable catalog of Earth observation and scientific datasets that is actively maintained and updated by the Copernicus Data Space Ecosystem. The integrated STAC (SpatioTemporal Asset Catalog) API, which follows the open STAC specification, enables users to access detailed asset-level metadata, including spatial information, temporal coverage, and data specifications. This standardized interface facilitates efficient data discovery and retrieval across the extensive collection of environmental and scientific resources. More information: https://documentation.dataspace.copernicus.eu/

julia> fill(catalog, 4)
4-element Vector{STAC.Catalog}:
 cdse-stac
 cdse-stac
 cdse-stac
 cdse-stac
 
 julia> item
S2C_MSIL1C_20260209T102201_N0512_R065_T32TPQ_20260209T123710
bounding box:
    ┌────── 45.14675───────┐
    │                      │
 10.25062               11.02458
    │                      │
    └────── 44.15222───────┘

date time: 2026-02-09T10:22:01.025
Assets:
   * B01: Coastal aerosol (band 1) - 60m
   * B02: Blue (band 2) - 10m
   * B03: Green (band 3) - 10m
   * B04: Red (band 4) - 10m
   * B05: Red edge 1 (band 5) - 20m
[...]

julia> fill(item, 4)
4-element Vector{STAC.Item}:
 S2C_MSIL1C_20260209T102201_N0512_R065_T32TPQ_20260209T123710
 S2C_MSIL1C_20260209T102201_N0512_R065_T32TPQ_20260209T123710
 S2C_MSIL1C_20260209T102201_N0512_R065_T32TPQ_20260209T123710
 S2C_MSIL1C_20260209T102201_N0512_R065_T32TPQ_20260209T123710

julia> fill(item.assets["B02"], 4)
4-element Vector{STAC.Asset}:
 Blue (band 2) - 10m
 Blue (band 2) - 10m
 Blue (band 2) - 10m
 Blue (band 2) - 10m
```
This will only show the id of a catalog or item and only the title of an asset if presented in an array, e.g. vector of search results.
This does not affect showing individual catalogs, items or assets.
Please merge #31 first to fix previous issues in showing datetime.